### PR TITLE
Add Django hardware checkout skeleton

### DIFF
--- a/hardware_checkout/.gitignore
+++ b/hardware_checkout/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+__pycache__/
+venv/
+.env
+/staticfiles/

--- a/hardware_checkout/README.md
+++ b/hardware_checkout/README.md
@@ -12,10 +12,13 @@ This is a minimal Django skeleton for tracking hardware loans, inventory status 
 ## Setup
 
 1. Install Python 3.11 and `pip`.
-2. Install dependencies:
+2. Install dependencies using the provided requirements file:
    ```bash
-   pip install django psycopg2-binary
+   pip install -r requirements.txt
    ```
+   If you are in an environment without internet access, make sure the required
+   packages (e.g. `Django` and `psycopg2-binary`) are available in your Python
+   installation.
 3. Configure PostgreSQL credentials using environment variables:
    - `POSTGRES_DB`
    - `POSTGRES_USER`

--- a/hardware_checkout/README.md
+++ b/hardware_checkout/README.md
@@ -1,0 +1,35 @@
+# Hardware Checkout Tracker Web App
+
+This is a minimal Django skeleton for tracking hardware loans, inventory status and service history.
+
+## Features
+
+- Inventory of hardware items with barcode IDs
+- Checkout and checkin hardware to staff users
+- Simple admin site to manage inventory and audit logs
+- Placeholder views for exporting reports as Excel or PDF
+
+## Setup
+
+1. Install Python 3.11 and `pip`.
+2. Install dependencies:
+   ```bash
+   pip install django psycopg2-binary
+   ```
+3. Configure PostgreSQL credentials using environment variables:
+   - `POSTGRES_DB`
+   - `POSTGRES_USER`
+   - `POSTGRES_PASSWORD`
+   - `POSTGRES_HOST`
+   - `POSTGRES_PORT`
+4. Run migrations and start the server:
+   ```bash
+   python manage.py migrate
+   python manage.py createsuperuser
+   python manage.py runserver
+   ```
+5. Access the site at `http://localhost:8000/`.
+
+## Note
+
+This repository contains only the basic skeleton of the application without third-party dependencies for PDF or Excel export. You can integrate packages such as `openpyxl` for Excel and `reportlab` or `weasyprint` for PDF.

--- a/hardware_checkout/hardware_checkout/__init__.py
+++ b/hardware_checkout/hardware_checkout/__init__.py
@@ -1,0 +1,1 @@
+"""Project module for hardware checkout tracker."""

--- a/hardware_checkout/hardware_checkout/settings.py
+++ b/hardware_checkout/hardware_checkout/settings.py
@@ -1,0 +1,89 @@
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = 'replace-this-key'
+
+DEBUG = True
+
+ALLOWED_HOSTS = []
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'inventory',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'hardware_checkout.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [BASE_DIR / 'templates'],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'hardware_checkout.wsgi.application'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('POSTGRES_DB', 'hardwaredb'),
+        'USER': os.getenv('POSTGRES_USER', 'postgres'),
+        'PASSWORD': os.getenv('POSTGRES_PASSWORD', 'postgres'),
+        'HOST': os.getenv('POSTGRES_HOST', 'localhost'),
+        'PORT': os.getenv('POSTGRES_PORT', '5432'),
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_TZ = True
+
+STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/hardware_checkout/hardware_checkout/urls.py
+++ b/hardware_checkout/hardware_checkout/urls.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from django.urls import path, include
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('', include('inventory.urls')),
+]

--- a/hardware_checkout/hardware_checkout/wsgi.py
+++ b/hardware_checkout/hardware_checkout/wsgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hardware_checkout.settings')
+
+application = get_wsgi_application()

--- a/hardware_checkout/inventory/__init__.py
+++ b/hardware_checkout/inventory/__init__.py
@@ -1,0 +1,1 @@
+"""Inventory app for hardware checkout."""

--- a/hardware_checkout/inventory/admin.py
+++ b/hardware_checkout/inventory/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from .models import Hardware, Loan, ServiceRecord, AuditLog
+
+admin.site.register(Hardware)
+admin.site.register(Loan)
+admin.site.register(ServiceRecord)
+admin.site.register(AuditLog)

--- a/hardware_checkout/inventory/apps.py
+++ b/hardware_checkout/inventory/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class InventoryConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'inventory'

--- a/hardware_checkout/inventory/models.py
+++ b/hardware_checkout/inventory/models.py
@@ -1,0 +1,33 @@
+from django.contrib.auth import get_user_model
+from django.db import models
+
+User = get_user_model()
+
+class Hardware(models.Model):
+    name = models.CharField(max_length=255)
+    barcode = models.CharField(max_length=255, unique=True)
+    serial_number = models.CharField(max_length=255, blank=True)
+    status = models.CharField(max_length=50, default='available')
+
+    def __str__(self):
+        return self.name
+
+class Loan(models.Model):
+    hardware = models.ForeignKey(Hardware, on_delete=models.CASCADE)
+    borrower = models.ForeignKey(User, on_delete=models.CASCADE)
+    checked_out_at = models.DateTimeField(auto_now_add=True)
+    returned_at = models.DateTimeField(null=True, blank=True)
+
+    def __str__(self):
+        return f"{self.hardware} -> {self.borrower}"
+
+class ServiceRecord(models.Model):
+    hardware = models.ForeignKey(Hardware, on_delete=models.CASCADE)
+    description = models.TextField()
+    serviced_at = models.DateTimeField(auto_now_add=True)
+
+class AuditLog(models.Model):
+    action = models.CharField(max_length=255)
+    user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)
+    timestamp = models.DateTimeField(auto_now_add=True)
+    notes = models.TextField(blank=True)

--- a/hardware_checkout/inventory/templates/inventory/checkin.html
+++ b/hardware_checkout/inventory/templates/inventory/checkin.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Checkin {{ hardware.name }}</h1>
+<form method="post">
+    {% csrf_token %}
+    <button type="submit">Confirm Checkin</button>
+</form>
+</body>
+</html>

--- a/hardware_checkout/inventory/templates/inventory/checkout.html
+++ b/hardware_checkout/inventory/templates/inventory/checkout.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Checkout {{ hardware.name }}</h1>
+<form method="post">
+    {% csrf_token %}
+    <button type="submit">Confirm Checkout</button>
+</form>
+</body>
+</html>

--- a/hardware_checkout/inventory/templates/inventory/hardware_list.html
+++ b/hardware_checkout/inventory/templates/inventory/hardware_list.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hardware List</title>
+</head>
+<body>
+<h1>Hardware Inventory</h1>
+<table>
+    <tr>
+        <th>Name</th>
+        <th>Status</th>
+        <th>Actions</th>
+    </tr>
+    {% for item in hardware %}
+    <tr>
+        <td>{{ item.name }}</td>
+        <td>{{ item.status }}</td>
+        <td>
+            <a href="{% url 'checkout' item.pk %}">Checkout</a>
+            <a href="{% url 'checkin' item.pk %}">Checkin</a>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+<a href="{% url 'export_excel' %}">Export Excel</a> |
+<a href="{% url 'export_pdf' %}">Export PDF</a>
+</body>
+</html>

--- a/hardware_checkout/inventory/urls.py
+++ b/hardware_checkout/inventory/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.hardware_list, name='hardware_list'),
+    path('checkout/<int:pk>/', views.checkout, name='checkout'),
+    path('checkin/<int:pk>/', views.checkin, name='checkin'),
+    path('export/excel/', views.export_excel, name='export_excel'),
+    path('export/pdf/', views.export_pdf, name='export_pdf'),
+]

--- a/hardware_checkout/inventory/views.py
+++ b/hardware_checkout/inventory/views.py
@@ -1,0 +1,48 @@
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponse
+from django.shortcuts import render, get_object_or_404, redirect
+from django.urls import reverse
+from django.utils import timezone
+
+from .models import Hardware, Loan, AuditLog
+
+@login_required
+def hardware_list(request):
+    hardware = Hardware.objects.all()
+    return render(request, 'inventory/hardware_list.html', {'hardware': hardware})
+
+@login_required
+def checkout(request, pk):
+    hardware = get_object_or_404(Hardware, pk=pk)
+    if request.method == 'POST':
+        Loan.objects.create(hardware=hardware, borrower=request.user)
+        AuditLog.objects.create(action='checkout', user=request.user, notes=str(hardware))
+        hardware.status = 'checked_out'
+        hardware.save()
+        return redirect(reverse('hardware_list'))
+    return render(request, 'inventory/checkout.html', {'hardware': hardware})
+
+@login_required
+def checkin(request, pk):
+    hardware = get_object_or_404(Hardware, pk=pk)
+    loan = Loan.objects.filter(hardware=hardware, returned_at__isnull=True).last()
+    if request.method == 'POST' and loan:
+        loan.returned_at = timezone.now()
+        loan.save()
+        AuditLog.objects.create(action='checkin', user=request.user, notes=str(hardware))
+        hardware.status = 'available'
+        hardware.save()
+        return redirect(reverse('hardware_list'))
+    return render(request, 'inventory/checkin.html', {'hardware': hardware})
+
+@login_required
+def export_excel(request):
+    # placeholder for Excel export
+    response = HttpResponse('Excel export placeholder', content_type='text/plain')
+    return response
+
+@login_required
+def export_pdf(request):
+    # placeholder for PDF export
+    response = HttpResponse('PDF export placeholder', content_type='text/plain')
+    return response

--- a/hardware_checkout/manage.py
+++ b/hardware_checkout/manage.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'hardware_checkout.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and available on your PYTHONPATH environment variable? Did you forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/hardware_checkout/requirements.txt
+++ b/hardware_checkout/requirements.txt
@@ -1,0 +1,2 @@
+django
+psycopg2-binary


### PR DESCRIPTION
## Summary
- create Django project with `hardware_checkout` and `inventory` app
- add basic models, views and templates
- configure PostgreSQL in settings
- include setup instructions in README

## Testing
- `python3 -m py_compile hardware_checkout/manage.py hardware_checkout/hardware_checkout/settings.py hardware_checkout/inventory/models.py hardware_checkout/inventory/views.py`

------
https://chatgpt.com/codex/tasks/task_e_685f3e092c4083338a966a73d8886b6f